### PR TITLE
chore: use latest for lighthouse default tag

### DIFF
--- a/src/app/api/controller/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/app/api/controller/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "specId": "lighthouse-beacon",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "displayName": "Lighthouse",
   "execution": {
     "executionTypes": ["docker", "binary"],
@@ -26,7 +26,7 @@
       "docker": ["amd64", "arm64"]
     },
     "imageName": "docker.io/sigp/lighthouse",
-    "defaultImageTag": "latest-modern",
+    "defaultImageTag": "latest",
     "binaryDownload": {
       "type": "githubReleases",
       "latestVersionUrl": "https://api.github.com/repos/sigp/lighthouse/releases/latest",


### PR DESCRIPTION
lighthouse changed `latest-modern` -> `latest` for default docker image tags and deprecated modern in https://github.com/sigp/lighthouse/releases/tag/v5.3.0