### PR TITLE
fix: update checkpointSyncUrl for Holesky and Sepolia configurations

### DIFF
--- a/src/app/api/controller/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/app/api/controller/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -68,11 +68,11 @@
           },
           {
             "value": "Holesky",
-            "config": "holesky"
+            "config": "holesky --checkpointSyncUrl https://beaconstate-holesky.chainsafe.io"
           },
           {
             "value": "Sepolia",
-            "config": "sepolia"
+            "config": "sepolia --checkpointSyncUrl https://beaconstate-sepolia.chainsafe.io"
           }
         ]
       }


### PR DESCRIPTION
This PR updates the checkpointSyncUrl configuration for Holesky and Sepolia networks in the lodestar specs.

### Changes
- Updates the checkpoint sync URL configuration to ensure proper synchronization for:
  - Holesky testnet
  - Sepolia testnet

### Why
The checkpoint sync URLs needed to be updated to maintain compatibility with the latest network configurations and ensure reliable node synchronization.

### Tested
- Verified checkpoint sync functionality on Holesky testnet
- Verified checkpoint sync functionality on Sepolia testnet

### Related Issues
https://github.com/NiceNode/nice-node/issues/451