### PR TITLE
fix: checkpoint sync testnets for prysm and lighthouse

### DIFF
--- a/src/app/api/controller/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/app/api/controller/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "specId": "lighthouse-beacon",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "displayName": "Lighthouse",
   "execution": {
     "executionTypes": ["docker", "binary"],
@@ -80,11 +80,11 @@
           },
           {
             "value": "Holesky",
-            "config": "holesky"
+            "config": "holesky --checkpoint-sync-url https://holesky.beaconstate.info"
           },
           {
             "value": "Sepolia",
-            "config": "sepolia"
+            "config": "sepolia --checkpoint-sync-url https://checkpoint-sync.sepolia.ethpandaops.io"
           }
         ]
       }

--- a/src/app/api/controller/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/app/api/controller/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "specId": "lodestar-beacon",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "Lodestar",
   "execution": {
     "executionTypes": ["docker"],

--- a/src/app/api/controller/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/app/api/controller/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "specId": "prysm-beacon",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "Prysm",
   "execution": {
     "executionTypes": ["docker"],
@@ -68,11 +68,11 @@
           },
           {
             "value": "Holesky",
-            "config": "--holesky"
+            "config": "--holesky --checkpoint-sync-url=https://holesky.beaconstate.ethstaker.cc/"
           },
           {
             "value": "Sepolia",
-            "config": "--sepolia"
+            "config": "--sepolia --checkpoint-sync-url=https://sepolia.beaconstate.info"
           }
         ]
       }


### PR DESCRIPTION
note: nimbus has a unique checkpoint sync process (too much work for us). and Teku seems to be compatible but it looks like we haven't tested it yet